### PR TITLE
exception handling getAuthUrl

### DIFF
--- a/src/main/java/com/mercadolibre/sdk/Meli.java
+++ b/src/main/java/com/mercadolibre/sdk/Meli.java
@@ -180,7 +180,7 @@ public class Meli {
 			    + clientId
 			    + "&redirect_uri="
 			    + URLEncoder.encode(callback, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
+		} catch (IllegalArgumentException e) {
 		    return "https://auth.mercadolibre.com.ar/authorization?response_type=code&client_id="
 			    + clientId + "&redirect_uri=" + callback;
 		}


### PR DESCRIPTION
UnsupportedCodingException solamente se tira al no reconocer el encoding definido en el segundo parametro.  Como aqui esta 'hard-coded' a UTF-8 (un valor que JVM siempre va a reconocer), es imposible activar el catch.    Un IllegalArgumentException es mas apropiado para capturar errores ocasionados por el primer parametro ("callback") 